### PR TITLE
Fix typo in docs that prevents code example from rendering

### DIFF
--- a/docs/pages/extra-columns.rst
+++ b/docs/pages/extra-columns.rst
@@ -35,6 +35,7 @@ The `wall_time` (i.e. the time a clock on the wall would show) when the events a
 The timestamp is not human-readable. Therefore, you might want to convert the timestamp to a `datetime` compliant object, as follows:
 
 .. code::
+
     from tbparse import SummaryReader
     log_dir = "<PATH_TO_EVENT_FILE_OR_DIRECTORY>"
     reader = SummaryReader(logdir, extra_columns={'wall_time'})


### PR DESCRIPTION
The documentation has a section on the `wall_time` extra column, that's supposed to include an example showing how to convert the wall times to normal python datetime objects.  However, the actual code snippet is not visible in the online docs.  I'm pretty sure that this is because there's no blank line between the directive and the snippet.

I wasn't able to test this change, because I ran into some errors while trying to build the docs that didn't seem easy to fix.  But like I said, I'm pretty sure that this is the cause of the problem.

